### PR TITLE
print the generated Token and TlsCA for exporters

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -45,6 +45,7 @@ var applyCmd = &cobra.Command{
 		debugConfigs, _ := cmd.Flags().GetBool("debug-configs")
 		filterClients, _ := cmd.Flags().GetString("filter-clients")
 		filterExporters, _ := cmd.Flags().GetString("filter-exporters")
+		printCredentials, _ := cmd.Flags().GetBool("print-exporter-credentials")
 
 		// Determine config file path
 		configFilePath := defaultConfigFile
@@ -97,7 +98,8 @@ var applyCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("error applying template for %s: %w", inst.Name, err)
 			}
-			instanceClient, err := instance.NewInstance(instanceCopy, instanceCopy.Spec.Kubeconfig, dryRun, prune)
+			instanceClient, err := instance.NewInstance(instanceCopy, instanceCopy.Spec.Kubeconfig, dryRun, prune,
+				printCredentials)
 			if err != nil {
 				return fmt.Errorf("error creating instance for %s: %w", inst.Name, err)
 			}
@@ -133,6 +135,7 @@ func init() {
 	applyCmd.Flags().Bool("debug-configs", false, "Show debug configs")
 	applyCmd.Flags().String("filter-clients", "", "Regexp pattern to filter clients by name")
 	applyCmd.Flags().String("filter-exporters", "", "Regexp pattern to filter exporters by name")
+	applyCmd.Flags().Bool("print-exporter-credentials", false, "Print connection details for exporters")
 
 	rootCmd.AddCommand(applyCmd)
 }

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -22,16 +22,17 @@ const (
 
 // Instance wraps a Kubernetes client and provides methods for operating on Jumpstarter resources
 type Instance struct {
-	client client.Client
-	config *v1alphaConfig.JumpstarterInstance
-	dryRun bool
-	prune  bool
+	client           client.Client
+	config           *v1alphaConfig.JumpstarterInstance
+	dryRun           bool
+	prune            bool
+	printCredentials bool
 }
 
 // NewInstance creates a new Instance from a JumpstarterInstance and optional kubeconfig string
 // If kubeconfigStr is empty, it will try to load from environment/standard kubeconfig file
 // This function ensures proper scheme registration for all custom API types
-func NewInstance(instance *v1alphaConfig.JumpstarterInstance, kubeconfigStr string, dryRun, prune bool) (*Instance, error) {
+func NewInstance(instance *v1alphaConfig.JumpstarterInstance, kubeconfigStr string, dryRun, prune, printCredentials bool) (*Instance, error) {
 	// Validate the instance
 	if err := validateInstance(instance); err != nil {
 		return nil, fmt.Errorf("invalid instance: %w", err)
@@ -88,10 +89,11 @@ func NewInstance(instance *v1alphaConfig.JumpstarterInstance, kubeconfigStr stri
 	}
 
 	return &Instance{
-		client: c,
-		config: instance,
-		dryRun: dryRun,
-		prune:  prune,
+		client:           c,
+		config:           instance,
+		dryRun:           dryRun,
+		prune:            prune,
+		printCredentials: printCredentials,
 	}, nil
 }
 

--- a/internal/instance/instance_test.go
+++ b/internal/instance/instance_test.go
@@ -28,7 +28,7 @@ func TestNewInstance(t *testing.T) {
 
 	t.Run("with kubeconfig string", func(t *testing.T) {
 		// This will likely fail since we don't have a real kubeconfig, but we test the flow
-		_, err := NewInstance(instance, validKubeconfig, false, false)
+		_, err := NewInstance(instance, validKubeconfig, false, false, false)
 		// We expect this to fail since the context doesn't exist in our test kubeconfig
 		if err != nil {
 			assert.Contains(t, err.Error(), "context test-context does not exist in kubeconfig")
@@ -37,7 +37,7 @@ func TestNewInstance(t *testing.T) {
 
 	t.Run("without kubeconfig string", func(t *testing.T) {
 		// This will likely fail since we don't have a real kubeconfig file, but we test the flow
-		_, err := NewInstance(instance, "", false, false)
+		_, err := NewInstance(instance, "", false, false, false)
 		// We expect this to fail since the context doesn't exist in the default kubeconfig
 		if err != nil {
 			assert.True(t,
@@ -60,7 +60,7 @@ func TestNewInstance(t *testing.T) {
 			},
 		}
 
-		_, err := NewInstance(instanceNoContext, validKubeconfig, false, false)
+		_, err := NewInstance(instanceNoContext, validKubeconfig, false, false, false)
 		// This should work with our test kubeconfig since it uses the default context
 		if err != nil {
 			assert.True(t,
@@ -85,7 +85,7 @@ func TestInstanceMethods(t *testing.T) {
 
 	t.Run("GetClient and GetConfig", func(t *testing.T) {
 		// This will likely fail, but we test the method signatures
-		inst, err := NewInstance(instance, validKubeconfig, false, false)
+		inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 		if err == nil {
 			// If it succeeds, test the methods
 			client := inst.GetClient()
@@ -110,7 +110,7 @@ func TestInstanceExporterMethods(t *testing.T) {
 	}
 
 	t.Run("listExporters with namespace", func(t *testing.T) {
-		inst, err := NewInstance(instance, validKubeconfig, false, false)
+		inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 		if err == nil {
 			// Test that the method exists and can be called
 			ctx := context.Background()
@@ -143,7 +143,7 @@ func TestInstanceExporterMethods(t *testing.T) {
 			},
 		}
 
-		inst, err := NewInstance(instanceNoNamespace, validKubeconfig, false, false)
+		inst, err := NewInstance(instanceNoNamespace, validKubeconfig, false, false, false)
 		if err == nil {
 			ctx := context.Background()
 			exporters, err := inst.listExporters(ctx)
@@ -164,7 +164,7 @@ func TestInstanceExporterMethods(t *testing.T) {
 	})
 
 	t.Run("GetExporterByName", func(t *testing.T) {
-		inst, err := NewInstance(instance, validKubeconfig, false, false)
+		inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 		if err == nil {
 			ctx := context.Background()
 			exporter, err := inst.GetExporterByName(ctx, "test-exporter")
@@ -196,7 +196,7 @@ func TestInstanceExporterMethods(t *testing.T) {
 			},
 		}
 
-		inst, err := NewInstance(instanceNoNamespace, validKubeconfig, false, false)
+		inst, err := NewInstance(instanceNoNamespace, validKubeconfig, false, false, false)
 		if err == nil {
 			ctx := context.Background()
 			_, err := inst.GetExporterByName(ctx, "test-exporter")
@@ -220,7 +220,7 @@ func TestInstanceClientMethods(t *testing.T) {
 	}
 
 	t.Run("ListClients with namespace", func(t *testing.T) {
-		inst, err := NewInstance(instance, validKubeconfig, false, false)
+		inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 		if err == nil {
 			ctx := context.Background()
 			clients, err := inst.ListClients(ctx)
@@ -242,7 +242,7 @@ func TestInstanceClientMethods(t *testing.T) {
 	})
 
 	t.Run("GetClientByName", func(t *testing.T) {
-		inst, err := NewInstance(instance, validKubeconfig, false, false)
+		inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 		if err == nil {
 			ctx := context.Background()
 			client, err := inst.GetClientByName(ctx, "test-client")
@@ -274,7 +274,7 @@ func TestInstanceClientMethods(t *testing.T) {
 			},
 		}
 
-		inst, err := NewInstance(instanceNoNamespace, validKubeconfig, false, false)
+		inst, err := NewInstance(instanceNoNamespace, validKubeconfig, false, false, false)
 		if err == nil {
 			ctx := context.Background()
 			_, err := inst.GetClientByName(ctx, "test-client")
@@ -339,7 +339,7 @@ func TestPrintDiff(t *testing.T) {
 		}
 
 		// Create an instance to test the printDiff method
-		inst, err := NewInstance(instance, validKubeconfig, false, false)
+		inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 		if err == nil {
 			// This should not panic and should print a diff
 			inst.checkAndPrintDiff(oldObj, newObj, "exporter", "test-exporter", true)
@@ -356,7 +356,7 @@ func TestPrintDiff(t *testing.T) {
 		}
 
 		// Create an instance to test the printDiff method
-		inst, err := NewInstance(instance, validKubeconfig, false, false)
+		inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 		if err == nil {
 			// This should not panic and should indicate no changes
 			inst.checkAndPrintDiff(obj, obj, "exporter", "test-exporter", true)
@@ -379,7 +379,7 @@ func TestCheckAndPrintDiff(t *testing.T) {
 	}
 
 	// Create an instance for testing
-	inst, err := NewInstance(instance, validKubeconfig, false, false)
+	inst, err := NewInstance(instance, validKubeconfig, false, false, false)
 	require.NoError(t, err)
 
 	t.Run("identical objects should return false", func(t *testing.T) {


### PR DESCRIPTION
this is mostly for on-desk exporters. for managed hosts this is handled automatically (but the print should not hurt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a CLI flag to optionally print exporter credentials as a copy-pastable YAML snippet (endpoint, TLS/insecure, and token). Snippets are labeled by instance and exporter and are emitted during create, update, and credential-wait flows; dry-run tokens may be placeholder.
- Chores
  - Per-instance control for credential printing wired into instance creation; no other behavioral changes.
- Tests
  - Updated tests to accommodate the new per-instance flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->