### PR TITLE
Retry on falied exporter host applies

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -34,8 +34,10 @@ import (
 var applyCmd = &cobra.Command{
 	Use:   "apply [config-file]",
 	Short: "Apply configuration changes",
-	Long:  `Apply configuration changes to the jumpstarter controllers. Use --dry-run to verify changes before applying.`,
-	Args:  cobra.MaximumNArgs(1),
+	Long: `Apply configuration changes to the jumpstarter controllers. ` +
+		`Use --dry-run to verify changes before applying.`,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		prune, _ := cmd.Flags().GetBool("prune")

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -38,7 +38,8 @@ var docsCmd = &cobra.Command{
 	Short: "Generate documentation for configured DUTs",
 	Long: `Generate markdown documentation table for all Device Under Test (DUT) boards with location and ` +
 		`status information. You do not need vault password file when all the fields in the output are not encrypted.`,
-	Args: cobra.MaximumNArgs(1),
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vaultPassFile, _ := cmd.Flags().GetString("vault-password-file")
 		outFile, _ := cmd.Flags().GetString("out")

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -26,10 +26,11 @@ import (
 )
 
 var lintCmd = &cobra.Command{
-	Use:   "lint [config-file]",
-	Short: "Validate configuration files",
-	Long:  `Lint and validate configuration files to ensure they are valid and follow the expected format.`,
-	Args:  cobra.MaximumNArgs(1),
+	Use:          "lint [config-file]",
+	Short:        "Validate configuration files",
+	Long:         `Lint and validate configuration files to ensure they are valid and follow the expected format.`,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vaultPassFile, _ := cmd.Flags().GetString("vault-password-file")
 		// Determine config file path


### PR DESCRIPTION
This also stops printing usage information on apply when there is an error happening, which didn't make any sense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a global retry mechanism with exponential backoff for exporter host synchronization, reducing transient failures and improving reliability. Includes sensible default retry settings and clearer final failure reporting.

- Bug Fixes
  - Improved CLI error output for apply, docs, and lint commands by suppressing usage text on errors, making messages clearer without altering command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->