### PR TITLE
Handle Service Parameters properly when having multiple jumpstarter instances

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -90,7 +90,8 @@ var applyCmd = &cobra.Command{
 			fmt.Println("Applying changes:")
 			fmt.Println()
 		}
-		var serviceParametersMap map[string]template.ServiceParameters
+		// create a serviceParametersMap to store the service parameters for the exporters in the jumpstarter instances
+		serviceParametersMap := make(map[string]template.ServiceParameters)
 
 		for _, inst := range cfg.Loaded.JumpstarterInstances {
 			instanceCopy := inst.DeepCopy()
@@ -109,9 +110,14 @@ var applyCmd = &cobra.Command{
 				return fmt.Errorf("error syncing clients for %s: %w", inst.Name, err)
 			}
 
-			serviceParametersMap, err = instanceClient.SyncExporters(context.Background(), cfg, exporterFilter)
+			instanceServiceParametersMap, err := instanceClient.SyncExporters(context.Background(), cfg, exporterFilter)
 			if err != nil {
 				return fmt.Errorf("error syncing exporters for %s: %w", inst.Name, err)
+			} else {
+				// merge instanceServiceParametersMap into serviceParametersMap
+				for k, v := range instanceServiceParametersMap {
+					serviceParametersMap[k] = v
+				}
 			}
 		}
 

--- a/internal/exporter/host/host.go
+++ b/internal/exporter/host/host.go
@@ -180,9 +180,10 @@ func (e *ExporterHostSyncer) processExporterInstance(exporterInstance *api.Expor
 		return fmt.Errorf("error creating ExporterInstanceTemplater for %s : %w", errName, err)
 	}
 
-	serviceParameters, ok := e.serviceParametersMap[exporterInstance.Name]
+	spRef := exporterInstance.Spec.JumpstarterInstanceRef.Name + ":" + exporterInstance.Name
+	serviceParameters, ok := e.serviceParametersMap[spRef]
 	if !ok {
-		return fmt.Errorf("service parameters not found for %s", exporterInstance.Name)
+		return fmt.Errorf("service parameters not found for %s", spRef)
 	}
 	et.SetServiceParameters(serviceParameters)
 

--- a/internal/instance/exporter_sync.go
+++ b/internal/instance/exporter_sync.go
@@ -342,7 +342,8 @@ func (i *Instance) SyncExporters(ctx context.Context, cfg *config.Config, filter
 				fmt.Printf("🔍 [%s] Exporter connection details snippet for exporter %s:\n%s\n", i.config.Name, cfgExporter.Name, yamlOutput)
 			}
 
-			serviceParametersMap[cfgExporter.Name] = *serviceParameters
+			svcParamRef := i.config.Name + ":" + cfgExporter.Name
+			serviceParametersMap[svcParamRef] = *serviceParameters
 		}
 	}
 
@@ -366,7 +367,8 @@ func (i *Instance) SyncExporters(ctx context.Context, cfg *config.Config, filter
 				}
 				fmt.Printf("🔍 [%s] Exporter connection details snippet for exporter %s:\n%s\n", i.config.Name, exporterObj.Name, yamlOutput)
 			}
-			serviceParametersMap[exporterObj.Name] = *serviceParameters
+			svcParamRef := i.config.Name + ":" + exporterObj.Name
+			serviceParametersMap[svcParamRef] = *serviceParameters
 		}
 	}
 


### PR DESCRIPTION
There was a bug in the code where only the last processed instance data was kept, the service parameters are the endpoint / auth details for exporter as received and synchronized from the K8s API